### PR TITLE
Fix DB issue and change default model to gpt-4o

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -88,7 +88,7 @@ async def register_user_if_not_exists(update: Update, context: CallbackContext, 
         user_semaphores[user.id] = asyncio.Semaphore(1)
 
     if db.get_user_attribute(user.id, "current_model") is None:
-        db.set_user_attribute(user.id, "current_model", config.models.default_text_model)
+        db.set_user_attribute(user.id, "current_model", config.models["default_text_model"])
 
     # back compatibility for n_used_tokens field
     n_used_tokens = db.get_user_attribute(user.id, "n_used_tokens")
@@ -562,7 +562,7 @@ async def new_dialog_handle(update: Update, context: CallbackContext):
 
     user_id = update.message.from_user.id
     db.set_user_attribute(user_id, "last_interaction", datetime.now())
-    db.set_user_attribute(user_id, "current_model", config.models.default_text_model)
+    db.set_user_attribute(user_id, "current_model", config.models["default_text_model"])
 
     db.start_new_dialog(user_id)
     await update.message.reply_text("Starting new dialog ✅")

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -88,7 +88,7 @@ async def register_user_if_not_exists(update: Update, context: CallbackContext, 
         user_semaphores[user.id] = asyncio.Semaphore(1)
 
     if db.get_user_attribute(user.id, "current_model") is None:
-        db.set_user_attribute(user.id, "current_model", config.models["available_text_models"][0])
+        db.set_user_attribute(user.id, "current_model", config.models.default_text_model)
 
     # back compatibility for n_used_tokens field
     n_used_tokens = db.get_user_attribute(user.id, "n_used_tokens")
@@ -562,7 +562,7 @@ async def new_dialog_handle(update: Update, context: CallbackContext):
 
     user_id = update.message.from_user.id
     db.set_user_attribute(user_id, "last_interaction", datetime.now())
-    db.set_user_attribute(user_id, "current_model", "gpt-3.5-turbo")
+    db.set_user_attribute(user_id, "current_model", config.models.default_text_model)
 
     db.start_new_dialog(user_id)
     await update.message.reply_text("Starting new dialog ✅")

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -459,11 +459,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
             await update.message.reply_text(text, parse_mode=ParseMode.HTML)
 
     async with user_semaphores[user_id]:
-        if current_model == "gpt-4-vision-preview" or current_model == "gpt-4o" or update.message.photo is not None and len(update.message.photo) > 0:
-
-            logger.error(current_model)
-            # What is this? ^^^
-
+        if update.message.photo:
             if current_model != "gpt-4o" and current_model != "gpt-4-vision-preview":
                 current_model = "gpt-4o"
                 db.set_user_attribute(user_id, "current_model", "gpt-4o")
@@ -473,7 +469,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
         else:
             task = asyncio.create_task(
                 message_handle_fn()
-            )            
+            )
 
         user_tasks[user_id] = task
 

--- a/bot/database.py
+++ b/bot/database.py
@@ -45,7 +45,7 @@ class Database:
 
             "current_dialog_id": None,
             "current_chat_mode": "assistant",
-            "current_model": config.models.default_text_model,
+            "current_model": config.models["default_text_model"],
 
             "n_used_tokens": {},
 

--- a/bot/database.py
+++ b/bot/database.py
@@ -45,7 +45,7 @@ class Database:
 
             "current_dialog_id": None,
             "current_chat_mode": "assistant",
-            "current_model": config.models["available_text_models"][0],
+            "current_model": config.models.default_text_model,
 
             "n_used_tokens": {},
 

--- a/bot/openai_utils.py
+++ b/bot/openai_utils.py
@@ -25,7 +25,7 @@ OPENAI_COMPLETION_OPTIONS = {
 
 
 class ChatGPT:
-    def __init__(self, model=config.models.default_text_model):
+    def __init__(self, model=config.models["default_text_model"]):
         assert model in {"text-davinci-003", "gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4o", "gpt-4-1106-preview", "gpt-4-vision-preview"}, f"Unknown model: {model}"
         self.model = model
 

--- a/bot/openai_utils.py
+++ b/bot/openai_utils.py
@@ -25,7 +25,7 @@ OPENAI_COMPLETION_OPTIONS = {
 
 
 class ChatGPT:
-    def __init__(self, model="gpt-3.5-turbo"):
+    def __init__(self, model=config.models.default_text_model):
         assert model in {"text-davinci-003", "gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4o", "gpt-4-1106-preview", "gpt-4-vision-preview"}, f"Unknown model: {model}"
         self.model = model
 

--- a/config/models.yml
+++ b/config/models.yml
@@ -1,4 +1,5 @@
 available_text_models: ["gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4-1106-preview", "gpt-4-vision-preview", "gpt-4", "text-davinci-003", "gpt-4o"]
+default_text_model: "gpt-4o"
 
 info:
   gpt-3.5-turbo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   mongo:
     container_name: mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - 127.0.0.1:${MONGODB_PORT:-27017}:${MONGODB_PORT:-27017}
     volumes:
       - ${MONGODB_PATH:-./mongodb}:/data/db
+    tmpfs:
+      - /data/configdb
     # TODO: add auth
 
   chatgpt_telegram_bot:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   mongo:
     container_name: mongo
     image: mongo:latest
-    restart: always
+    restart: unless-stopped
     ports:
       - 127.0.0.1:${MONGODB_PORT:-27017}:${MONGODB_PORT:-27017}
     volumes:
@@ -14,7 +14,7 @@ services:
   chatgpt_telegram_bot:
     container_name: chatgpt_telegram_bot
     command: python3 bot/bot.py
-    restart: always
+    restart: unless-stopped
     build:
       context: "."
       dockerfile: Dockerfile
@@ -24,7 +24,7 @@ services:
   mongo_express:
     container_name: mongo-express
     image: mongo-express:latest
-    restart: always
+    restart: unless-stopped
     ports:
       - 127.0.0.1:${MONGO_EXPRESS_PORT:-8081}:${MONGO_EXPRESS_PORT:-8081}
     environment:


### PR DESCRIPTION
## Summary
These changes helped me to resolve the issues described in https://github.com/father-bot/chatgpt_telegram_bot/issues/488
- Fixed questionable conditions in message handling, which sometimes triggered the wrong handler and likely caused DB issues under some circumstances
- Added `default_text_model` parameter in `models.yml` which helps to easily change the default model everywhere and changed the default model to `gpt-4o`
- Updated `docker-compose.yml`:
    1. Added `tmpfs` for `/db/configdb` to avoid creating a new anonymous empty volume on each run
    2. Removed `version` as it's deprecated
    3. Changed restart policy from `always` to `unless-stopped` to be able to stop containers if necessary without deleting them (e.g. could be helpful for debugging DB issues)

I've been testing these changes since the above issue was created, and they work fine so far.
No DB issues encountered since then.